### PR TITLE
Fix error in documentation

### DIFF
--- a/docs/src/data-management.md
+++ b/docs/src/data-management.md
@@ -90,7 +90,7 @@ cs = Dagger.@shard Threads.Atomic{Int}(0)
 wait.([Dagger.@spawn Threads.atomic_add!(cs, 1) for i in 1:1000])
 
 # And let's fetch the total sum of all counters:
-@assert sum(fetch.(map(ctr->ctr[], cs))) == 1000
+@assert sum(fetch.(map(ctr->Dagger.spawn(getindex,ctr), cs))) == 1000
 ```
 
 Note that `map`, when used on a shard, will execute the provided function once


### PR DESCRIPTION
For me there is an error when copy-pasting the sharding example in the documentation on Dagger 0.18.2 This is a fix that worked for me, no idea if there is a more idiomatic way to do it. 